### PR TITLE
Add login and multiple tabs

### DIFF
--- a/clairApp/app/(tabs)/_layout.tsx
+++ b/clairApp/app/(tabs)/_layout.tsx
@@ -29,15 +29,29 @@ export default function TabLayout() {
       <Tabs.Screen
         name="index"
         options={{
-          title: 'Home',
+          title: 'Startseite',
           tabBarIcon: ({ color }) => <IconSymbol size={28} name="house.fill" color={color} />,
         }}
       />
       <Tabs.Screen
-        name="explore"
+        name="dashboards"
         options={{
-          title: 'Explore',
-          tabBarIcon: ({ color }) => <IconSymbol size={28} name="paperplane.fill" color={color} />,
+          title: 'Dashboards',
+          tabBarIcon: ({ color }) => <IconSymbol size={28} name="chart.bar.fill" color={color} />,
+        }}
+      />
+      <Tabs.Screen
+        name="tasks"
+        options={{
+          title: 'Tasks',
+          tabBarIcon: ({ color }) => <IconSymbol size={28} name="checklist" color={color} />,
+        }}
+      />
+      <Tabs.Screen
+        name="profile"
+        options={{
+          title: 'Mein Profil',
+          tabBarIcon: ({ color }) => <IconSymbol size={28} name="person.circle.fill" color={color} />,
         }}
       />
     </Tabs>

--- a/clairApp/app/(tabs)/dashboards.tsx
+++ b/clairApp/app/(tabs)/dashboards.tsx
@@ -1,0 +1,10 @@
+import { ThemedView } from '@/components/ThemedView';
+import { ThemedText } from '@/components/ThemedText';
+
+export default function DashboardScreen() {
+  return (
+    <ThemedView style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <ThemedText type="title">Dashboards</ThemedText>
+    </ThemedView>
+  );
+}

--- a/clairApp/app/(tabs)/index.tsx
+++ b/clairApp/app/(tabs)/index.tsx
@@ -1,75 +1,35 @@
-import { Image } from 'expo-image';
-import { Platform, StyleSheet } from 'react-native';
-
-import { HelloWave } from '@/components/HelloWave';
-import ParallaxScrollView from '@/components/ParallaxScrollView';
-import { ThemedText } from '@/components/ThemedText';
+import { useState } from 'react';
+import { Button, FlatList, Text, TextInput } from 'react-native';
 import { ThemedView } from '@/components/ThemedView';
+import { ThemedText } from '@/components/ThemedText';
 
 export default function HomeScreen() {
+  const [widgets, setWidgets] = useState<string[]>([]);
+  const [text, setText] = useState('');
+
+  const addWidget = () => {
+    if (text.trim()) {
+      setWidgets([...widgets, text.trim()]);
+      setText('');
+    }
+  };
+
   return (
-    <ParallaxScrollView
-      headerBackgroundColor={{ light: '#A1CEDC', dark: '#1D3D47' }}
-      headerImage={
-        <Image
-          source={require('@/assets/images/partial-react-logo.png')}
-          style={styles.reactLogo}
-        />
-      }>
-      <ThemedView style={styles.titleContainer}>
-        <ThemedText type="title">Welcome!</ThemedText>
-        <HelloWave />
-      </ThemedView>
-      <ThemedView style={styles.stepContainer}>
-        <ThemedText type="subtitle">Step 1: Try it</ThemedText>
-        <ThemedText>
-          Edit <ThemedText type="defaultSemiBold">app/(tabs)/index.tsx</ThemedText> to see changes.
-          Press{' '}
-          <ThemedText type="defaultSemiBold">
-            {Platform.select({
-              ios: 'cmd + d',
-              android: 'cmd + m',
-              web: 'F12',
-            })}
-          </ThemedText>{' '}
-          to open developer tools.
-        </ThemedText>
-      </ThemedView>
-      <ThemedView style={styles.stepContainer}>
-        <ThemedText type="subtitle">Step 2: Explore</ThemedText>
-        <ThemedText>
-          {`Tap the Explore tab to learn more about what's included in this starter app.`}
-        </ThemedText>
-      </ThemedView>
-      <ThemedView style={styles.stepContainer}>
-        <ThemedText type="subtitle">Step 3: Get a fresh start</ThemedText>
-        <ThemedText>
-          {`When you're ready, run `}
-          <ThemedText type="defaultSemiBold">npm run reset-project</ThemedText> to get a fresh{' '}
-          <ThemedText type="defaultSemiBold">app</ThemedText> directory. This will move the current{' '}
-          <ThemedText type="defaultSemiBold">app</ThemedText> to{' '}
-          <ThemedText type="defaultSemiBold">app-example</ThemedText>.
-        </ThemedText>
-      </ThemedView>
-    </ParallaxScrollView>
+    <ThemedView style={{ flex: 1, padding: 16 }}>
+      <ThemedText type="title">Startseite</ThemedText>
+      <TextInput
+        placeholder="Neues Widget"
+        value={text}
+        onChangeText={setText}
+        style={{ borderWidth: 1, marginVertical: 8, padding: 8 }}
+      />
+      <Button title="Widget hinzufügen" onPress={addWidget} />
+      <FlatList
+        data={widgets}
+        keyExtractor={(item, index) => index.toString()}
+        renderItem={({ item }) => <Text>{item}</Text>}
+        style={{ marginTop: 16 }}
+      />
+    </ThemedView>
   );
 }
-
-const styles = StyleSheet.create({
-  titleContainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-  },
-  stepContainer: {
-    gap: 8,
-    marginBottom: 8,
-  },
-  reactLogo: {
-    height: 178,
-    width: 290,
-    bottom: 0,
-    left: 0,
-    position: 'absolute',
-  },
-});

--- a/clairApp/app/(tabs)/profile.tsx
+++ b/clairApp/app/(tabs)/profile.tsx
@@ -1,0 +1,17 @@
+import { useContext } from 'react';
+import { Button } from 'react-native';
+import { AuthContext } from '@/contexts/AuthContext';
+import { ThemedView } from '@/components/ThemedView';
+import { ThemedText } from '@/components/ThemedText';
+
+export default function ProfileScreen() {
+  const { token, setToken } = useContext(AuthContext);
+
+  return (
+    <ThemedView style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: 16 }}>
+      <ThemedText type="title">Mein Profil</ThemedText>
+      {token && <ThemedText>{token.substring(0, 20)}...</ThemedText>}
+      <Button title="Logout" onPress={() => setToken(null)} />
+    </ThemedView>
+  );
+}

--- a/clairApp/app/(tabs)/tasks.tsx
+++ b/clairApp/app/(tabs)/tasks.tsx
@@ -1,0 +1,39 @@
+import { useContext, useEffect, useState } from 'react';
+import { FlatList, Text } from 'react-native';
+import { AuthContext } from '@/contexts/AuthContext';
+import { ThemedView } from '@/components/ThemedView';
+import { ThemedText } from '@/components/ThemedText';
+
+interface Task {
+  id?: string;
+  title?: string;
+}
+
+export default function TasksScreen() {
+  const { token } = useContext(AuthContext);
+  const [tasks, setTasks] = useState<Task[]>([]);
+
+  useEffect(() => {
+    if (!token) return;
+    fetch('https://app-app-nightly-be-vcur.azurewebsites.net/v1/Tasks', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((r) => r.json())
+      .then((data) => setTasks(Array.isArray(data) ? data : []))
+      .catch((err) => console.error(err));
+  }, [token]);
+
+  return (
+    <ThemedView style={{ flex: 1, padding: 16 }}>
+      <ThemedText type="title">Tasks</ThemedText>
+      <FlatList
+        data={tasks}
+        keyExtractor={(item, index) => String(item.id ?? index)}
+        renderItem={({ item }) => (
+          <Text>{item.title ?? JSON.stringify(item)}</Text>
+        )}
+        ListEmptyComponent={<Text>Keine Tasks gefunden</Text>}
+      />
+    </ThemedView>
+  );
+}

--- a/clairApp/app/_layout.tsx
+++ b/clairApp/app/_layout.tsx
@@ -5,6 +5,8 @@ import { StatusBar } from 'expo-status-bar';
 import 'react-native-reanimated';
 
 import { useColorScheme } from '@/hooks/useColorScheme';
+import { AuthProvider, AuthContext } from '@/contexts/AuthContext';
+import { useContext } from 'react';
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();
@@ -18,9 +20,24 @@ export default function RootLayout() {
   }
 
   return (
+    <AuthProvider>
+      <RootNavigation colorScheme={colorScheme} />
+    </AuthProvider>
+  );
+}
+
+import type { ColorSchemeName } from 'react-native';
+
+function RootNavigation({ colorScheme }: { colorScheme: ColorSchemeName }) {
+  const { token } = useContext(AuthContext);
+  return (
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
       <Stack>
-        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        {token ? (
+          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        ) : (
+          <Stack.Screen name="login" options={{ headerShown: false }} />
+        )}
         <Stack.Screen name="+not-found" />
       </Stack>
       <StatusBar style="auto" />

--- a/clairApp/app/login.tsx
+++ b/clairApp/app/login.tsx
@@ -1,0 +1,35 @@
+import { Stack, useRouter } from 'expo-router';
+import { useContext, useState } from 'react';
+import { Button, TextInput } from 'react-native';
+import { AuthContext } from '@/contexts/AuthContext';
+import { ThemedView } from '@/components/ThemedView';
+import { ThemedText } from '@/components/ThemedText';
+
+export default function LoginScreen() {
+  const { setToken } = useContext(AuthContext);
+  const [value, setValue] = useState('');
+  const router = useRouter();
+
+  const handleLogin = () => {
+    if (value.trim()) {
+      setToken(value.trim());
+      router.replace('/');
+    }
+  };
+
+  return (
+    <>
+      <Stack.Screen options={{ title: 'Login' }} />
+      <ThemedView style={{ flex: 1, justifyContent: 'center', padding: 16 }}>
+        <ThemedText type="title">Login</ThemedText>
+        <TextInput
+          placeholder="Token"
+          value={value}
+          onChangeText={setValue}
+          style={{ borderWidth: 1, marginVertical: 12, padding: 8 }}
+        />
+        <Button title="Anmelden" onPress={handleLogin} />
+      </ThemedView>
+    </>
+  );
+}

--- a/clairApp/components/ui/IconSymbol.tsx
+++ b/clairApp/components/ui/IconSymbol.tsx
@@ -18,6 +18,9 @@ const MAPPING = {
   'paperplane.fill': 'send',
   'chevron.left.forwardslash.chevron.right': 'code',
   'chevron.right': 'chevron-right',
+  'chart.bar.fill': 'dashboard',
+  'checklist': 'assignment',
+  'person.circle.fill': 'person',
 } as IconMapping;
 
 /**

--- a/clairApp/contexts/AuthContext.tsx
+++ b/clairApp/contexts/AuthContext.tsx
@@ -1,0 +1,20 @@
+import React, { createContext, useState, ReactNode } from 'react';
+
+interface AuthContextType {
+  token: string | null;
+  setToken: (token: string | null) => void;
+}
+
+export const AuthContext = createContext<AuthContextType>({
+  token: null,
+  setToken: () => {},
+});
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [token, setToken] = useState<string | null>(null);
+  return (
+    <AuthContext.Provider value={{ token, setToken }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}


### PR DESCRIPTION
## Summary
- add basic auth context and login screen
- add dashboard, tasks, and profile tabs
- implement placeholder widget functionality on start page
- update bottom navigation icons
- switch root navigation depending on login state

## Testing
- `npm install`
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_68432db2f10c8333a51ea0d0b08a9ddc