### PR TITLE
Update tab colors and header

### DIFF
--- a/clairApp/app/(tabs)/_layout.tsx
+++ b/clairApp/app/(tabs)/_layout.tsx
@@ -15,7 +15,10 @@ export default function TabLayout() {
     <Tabs
       screenOptions={{
         tabBarActiveTintColor: Colors[colorScheme ?? 'light'].tint,
-        headerShown: false,
+        headerShown: true,
+        headerStyle: { backgroundColor: Colors[colorScheme ?? 'light'].tint },
+        headerTitleStyle: { color: '#ffffff' },
+        headerTintColor: '#ffffff',
         tabBarButton: HapticTab,
         tabBarBackground: TabBarBackground,
         tabBarStyle: Platform.select({

--- a/clairApp/constants/Colors.ts
+++ b/clairApp/constants/Colors.ts
@@ -3,8 +3,8 @@
  * There are many other ways to style your app. For example, [Nativewind](https://www.nativewind.dev/), [Tamagui](https://tamagui.dev/), [unistyles](https://reactnativeunistyles.vercel.app), etc.
  */
 
-const tintColorLight = '#0a7ea4';
-const tintColorDark = '#fff';
+const tintColorLight = '#007E7A';
+const tintColorDark = '#007E7A';
 
 export const Colors = {
   light: {


### PR DESCRIPTION
## Summary
- update tint colors to `#007E7A`
- display a header for every tab
- set the header background to the tint color with white text

## Testing
- `npx expo lint` *(fails: needs expo installed)*

------
https://chatgpt.com/codex/tasks/task_e_684333ea3b0c833391b214afa06ccd3e